### PR TITLE
bls-device: add bls-device-harness CLI (S.02 operator dispatch path)

### DIFF
--- a/bls-device/Cargo.toml
+++ b/bls-device/Cargo.toml
@@ -12,6 +12,10 @@ path = "src/lib.rs"
 name = "record-fixture"
 path = "src/bin/record_fixture.rs"
 
+[[bin]]
+name = "bls-device-harness"
+path = "src/bin/harness.rs"
+
 [dependencies]
 blst = "0.3"
 sha2 = "0.10"

--- a/bls-device/src/bin/harness.rs
+++ b/bls-device/src/bin/harness.rs
@@ -1,0 +1,96 @@
+//! `bls-device-harness` — operator CLI wrapping `bls_device::Device::verify`.
+//!
+//! Reads a `VerifyRequest` JSON object from stdin, runs the eight-stage
+//! O-701 pipeline against a real beacon endpoint, prints the
+//! `VerifyResponse` JSON to stdout.
+//!
+//! Used by paxiom's `services/sync-committee/dispatch.mjs` when run with
+//! `BLS_DEVICE_VIA_SUBPROCESS=1` — i.e. the operator-side S.02 dispatch
+//! path that doesn't require HyperBEAM to be up. Also useful for ad-hoc
+//! verification: pipe a JSON request in, get a verified response out.
+//!
+//! Configuration via env (all optional, sensible defaults for mainnet):
+//!   BLS_DEVICE_BEACON_URL    — single beacon endpoint (default: Lodestar mainnet)
+//!   BLS_DEVICE_CACHE_PATH    — sqlite cache file (default: in-memory; ephemeral
+//!                              per invocation, fine for one-off verifies)
+//!   BLS_DEVICE_KEY_ID        — platform key id stamped into the response
+//!                              (default: "harness-key-1")
+//!
+//! Mainnet `genesis_validators_root` is compiled in (per O-701: a different
+//! chain id means a different deployment).
+//!
+//! Exit codes:
+//!   0  — JSON response printed to stdout (verified=true OR verified=false
+//!        with structured fields explaining why; this is the normal path)
+//!   1  — request parse failure (malformed stdin); error JSON to stderr
+//!   2  — pipeline error (beacon exhausted, primitive failure, etc.); error
+//!        JSON to stderr
+
+use std::sync::Arc;
+
+use bls_device::{
+    ao::MockAo,
+    beacon::default_mainnet_pool,
+    cache::SqliteCommitteeCache,
+    primitive::NativePrimitive,
+    x402::MockX402,
+    Device, VerifyRequest, MAINNET_GENESIS_VALIDATORS_ROOT,
+};
+
+#[tokio::main]
+async fn main() {
+    if let Err((code, body)) = run().await {
+        eprintln!("{}", body);
+        std::process::exit(code);
+    }
+}
+
+async fn run() -> Result<(), (i32, String)> {
+    use std::io::Read;
+    let mut input = String::new();
+    std::io::stdin()
+        .read_to_string(&mut input)
+        .map_err(|e| (1, error_json("stdin read failed", &e.to_string())))?;
+
+    let req: VerifyRequest = serde_json::from_str(&input)
+        .map_err(|e| (1, error_json("request parse failed", &e.to_string())))?;
+
+    let beacon_url = std::env::var("BLS_DEVICE_BEACON_URL")
+        .unwrap_or_else(|_| "https://lodestar-mainnet.chainsafe.io".into());
+    let key_id = std::env::var("BLS_DEVICE_KEY_ID").unwrap_or_else(|_| "harness-key-1".into());
+    let cache = match std::env::var("BLS_DEVICE_CACHE_PATH").ok() {
+        Some(path) => SqliteCommitteeCache::open(path),
+        None => SqliteCommitteeCache::open_in_memory(),
+    }
+    .map_err(|e| (2, error_json("cache init failed", &e.to_string())))?;
+
+    let pool = Arc::new(default_mainnet_pool(&[("operator-supplied".into(), beacon_url)]));
+    let device = Device::new(
+        pool,
+        Arc::new(cache),
+        Arc::new(NativePrimitive),
+        Arc::new(MockX402),
+        Arc::new(MockAo),
+        MAINNET_GENESIS_VALIDATORS_ROOT,
+        key_id,
+    );
+
+    let resp = device
+        .verify(req, None)
+        .await
+        .map_err(|e| (2, error_json("device.verify failed", &e.to_string())))?;
+
+    let json = serde_json::to_string_pretty(&resp)
+        .map_err(|e| (2, error_json("response serialize failed", &e.to_string())))?;
+    println!("{}", json);
+    Ok(())
+}
+
+fn error_json(msg: &str, detail: &str) -> String {
+    serde_json::json!({
+        "error": msg,
+        "detail": detail,
+        "verified": false,
+    })
+    .to_string()
+}


### PR DESCRIPTION
## Summary

Closes a gap surfaced by the operator-gate run plan
(`/root/.claude/plans/i-want-to-build-lazy-gadget.md`, Step 0): the
paxiom service's `BLS_DEVICE_VIA_SUBPROCESS=1` dispatch path spawns
`bls-device-harness` and pipes JSON to stdin → expects JSON on stdout.
The library + `record-fixture` binary landed in #1; this harness binary
was filed as a follow-up. Adding it now so the operator can close
A-120 / S.02 without depending on HyperBEAM being perfect.

## What's added

- **`bls-device/src/bin/harness.rs`** — ~80-line CLI wrapper:
  - reads `VerifyRequest` JSON from stdin
  - constructs a `Device` with sensible mainnet defaults
    (`default_mainnet_pool`, in-memory or file-backed
    `SqliteCommitteeCache`, `NativePrimitive`, `MockX402`, `MockAo`,
    `MAINNET_GENESIS_VALIDATORS_ROOT`)
  - calls `device.verify(req, None)`
  - prints `VerifyResponse` JSON to stdout (pretty)
  - exits `0` on success, `1` on stdin/parse failure, `2` on pipeline
    error with structured JSON detail to stderr
- **`bls-device/Cargo.toml`** — `[[bin]] name = "bls-device-harness"`

## Configuration (all env, all optional)

| Var | Default | Purpose |
|---|---|---|
| `BLS_DEVICE_BEACON_URL` | `https://lodestar-mainnet.chainsafe.io` | single beacon endpoint |
| `BLS_DEVICE_CACHE_PATH` | (in-memory) | sqlite committee cache |
| `BLS_DEVICE_KEY_ID` | `harness-key-1` | platform key id stamped into response |

## Smoke tested locally

```bash
echo '{not valid json' | ./bls-device-harness
# → exit 1, "request parse failed" JSON on stderr

echo '{"slot":"1","block_root":"0xaa","parent_root":"0xbb","sync_aggregate":...}' \
  | ./bls-device-harness
# → exit 2, "device.verify failed: parent_root: expected 32 bytes" JSON
```

## Operator usage (closes S.02)

```bash
cargo build --release -p bls-device --bin bls-device-harness

# In paxiom checkout:
BLS_DEVICE_VIA_SUBPROCESS=1 \
BLS_DEVICE_HARNESS=$(realpath ~/bls-verifier/target/release/bls-device-harness) \
  node services/sync-committee/server.mjs &

./hyperbeam/bringup/capture-gate-evidence.sh
# → verified: true; evidence JSON written to hyperbeam/bringup/evidence/
```

## Test plan

- [x] `cargo build --release -p bls-device --bin bls-device-harness` (1m44s on this box)
- [x] Stdin parse failure → exit 1 with structured JSON to stderr
- [x] Bad request body → exit 2 with structured JSON to stderr
- [ ] Operator: live mainnet head → exit 0, `verified: true` (this is the S.02 gate run)

https://claude.ai/code/session_01DbP822H3LNdWiUYG6PzX6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbP822H3LNdWiUYG6PzX6H)_