### PR TITLE
audit fixes: FFI safety + CLI panic handling

### DIFF
--- a/bls-verifier/src/lib.rs
+++ b/bls-verifier/src/lib.rs
@@ -46,13 +46,32 @@
 use blst::min_pk::{PublicKey, Signature, AggregatePublicKey};
 use blst::BLST_ERROR;
 
+/// # Safety
+///
+/// The caller is responsible for the standard FFI pointer-validity contract:
+/// - `pubkeys_ptr` must point to at least `pubkeys_len` valid bytes
+/// - `sig_ptr` must point to at least 96 valid bytes
+/// - `signing_root_ptr` must point to exactly 32 valid bytes
+/// - all three pointers must be non-null and properly aligned for `u8`
+/// - the memory must remain valid for the duration of this call
+///
+/// Null pointers and zero-length pubkeys input are detected and return -2
+/// (matching the "no pubkeys provided" error code) rather than segfaulting,
+/// but this defense is best-effort — any other invalid pointer is undefined
+/// behavior.
 #[no_mangle]
-pub extern "C" fn verify_sync_committee(
+pub unsafe extern "C" fn verify_sync_committee(
     pubkeys_ptr: *const u8,
     pubkeys_len: usize,
     sig_ptr: *const u8,
     signing_root_ptr: *const u8,
 ) -> i32 {
+    if sig_ptr.is_null() || signing_root_ptr.is_null() {
+        return -1;
+    }
+    if pubkeys_ptr.is_null() || pubkeys_len == 0 {
+        return -2;
+    }
     let pubkeys_bytes = unsafe { std::slice::from_raw_parts(pubkeys_ptr, pubkeys_len) };
     let sig_bytes = unsafe { std::slice::from_raw_parts(sig_ptr, 96) };
     let signing_root = unsafe { std::slice::from_raw_parts(signing_root_ptr, 32) };

--- a/bls-verify-cli/src/main.rs
+++ b/bls-verify-cli/src/main.rs
@@ -3,20 +3,41 @@ use blst::BLST_ERROR;
 use sha2::{Sha256, Digest};
 use std::io::{self, Read};
 
+type CliError = Box<dyn std::error::Error>;
+
 fn main() {
-    // Read JSON from stdin
+    if let Err(e) = run() {
+        eprintln!("bls-verify-cli: {e}");
+        println!("{}", serde_json::json!({"verified": false, "error": e.to_string()}));
+        std::process::exit(1);
+    }
+}
+
+fn require_str<'a>(v: &'a serde_json::Value, key: &'static str) -> Result<&'a str, CliError> {
+    v.get(key)
+        .and_then(|x| x.as_str())
+        .ok_or_else(|| format!("missing required string field: {key}").into())
+}
+
+fn require_array<'a>(v: &'a serde_json::Value, key: &'static str) -> Result<&'a Vec<serde_json::Value>, CliError> {
+    v.get(key)
+        .and_then(|x| x.as_array())
+        .ok_or_else(|| format!("missing required array field: {key}").into())
+}
+
+fn run() -> Result<(), CliError> {
     let mut input = String::new();
-    io::stdin().read_to_string(&mut input).unwrap();
+    io::stdin().read_to_string(&mut input)?;
 
-    let data: serde_json::Value = serde_json::from_str(&input).unwrap();
+    let data: serde_json::Value = serde_json::from_str(&input)
+        .map_err(|e| format!("stdin is not valid JSON: {e}"))?;
 
-    let sig_hex = data["signature"].as_str().unwrap().trim_start_matches("0x");
-    let bits_hex = data["bits"].as_str().unwrap().trim_start_matches("0x");
-    let parent_root_hex = data["parent_root"].as_str().unwrap().trim_start_matches("0x");
-    let pubkeys_array = data["pubkeys"].as_array().unwrap();
+    let sig_hex = require_str(&data, "signature")?.trim_start_matches("0x");
+    let bits_hex = require_str(&data, "bits")?.trim_start_matches("0x");
+    let parent_root_hex = require_str(&data, "parent_root")?.trim_start_matches("0x");
+    let pubkeys_array = require_array(&data, "pubkeys")?;
 
-    // Parse participation bits and filter pubkeys
-    let bits_bytes = hex_to_bytes(bits_hex);
+    let bits_bytes = hex_to_bytes(bits_hex)?;
     let mut participating_pubkeys: Vec<PublicKey> = vec![];
 
     for (i, pk_hex) in pubkeys_array.iter().enumerate() {
@@ -25,7 +46,9 @@ fn main() {
         if byte_idx < bits_bytes.len() {
             let participated = (bits_bytes[byte_idx] >> bit_idx) & 1 == 1;
             if participated {
-                let pk_bytes = hex_to_bytes(pk_hex.as_str().unwrap().trim_start_matches("0x"));
+                let pk_str = pk_hex.as_str()
+                    .ok_or_else(|| format!("pubkeys[{i}] is not a string"))?;
+                let pk_bytes = hex_to_bytes(pk_str.trim_start_matches("0x"))?;
                 if let Ok(pk) = PublicKey::from_bytes(&pk_bytes) {
                     participating_pubkeys.push(pk);
                 }
@@ -39,41 +62,25 @@ fn main() {
     // input field so this stays a pure function over byte buffers.
     let genesis_validators_root = hex_to_bytes(
         "4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95"
-    );
-    let fork_version_hex = data["fork_version"]
-        .as_str()
-        .expect("fork_version field is required (4-byte hex, e.g. \"0x06000000\")")
-        .trim_start_matches("0x");
-    let fork_version = hex_to_bytes(fork_version_hex);
+    )?;
+    let fork_version_hex = require_str(&data, "fork_version")?.trim_start_matches("0x");
+    let fork_version = hex_to_bytes(fork_version_hex)?;
     if fork_version.len() != 4 {
-        println!("{}", serde_json::json!({
-            "verified": false,
-            "error": format!("fork_version must be 4 bytes, got {}", fork_version.len())
-        }));
-        return;
+        return Err(format!("fork_version must be 4 bytes, got {}", fork_version.len()).into());
     }
     let domain = compute_domain(&fork_version, &genesis_validators_root);
-    let parent_root_bytes = hex_to_bytes(parent_root_hex);
+    let parent_root_bytes = hex_to_bytes(parent_root_hex)?;
     let signing_root = compute_signing_root(&parent_root_bytes, &domain);
 
     // Aggregate pubkeys and verify
     let pk_refs: Vec<&PublicKey> = participating_pubkeys.iter().collect();
-    let agg_pk = match AggregatePublicKey::aggregate(&pk_refs, true) {
-        Ok(a) => a.to_public_key(),
-        Err(e) => {
-            println!("{}", serde_json::json!({"verified": false, "error": format!("{:?}", e)}));
-            return;
-        }
-    };
+    let agg_pk = AggregatePublicKey::aggregate(&pk_refs, true)
+        .map_err(|e| format!("aggregate: {e:?}"))?
+        .to_public_key();
 
-    let sig_bytes = hex_to_bytes(sig_hex);
-    let sig = match Signature::from_bytes(&sig_bytes) {
-        Ok(s) => s,
-        Err(e) => {
-            println!("{}", serde_json::json!({"verified": false, "error": format!("{:?}", e)}));
-            return;
-        }
-    };
+    let sig_bytes = hex_to_bytes(sig_hex)?;
+    let sig = Signature::from_bytes(&sig_bytes)
+        .map_err(|e| format!("signature parse: {e:?}"))?;
 
     let dst = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
     let result = sig.verify(true, &signing_root, dst, &[], &agg_pk, true);
@@ -85,12 +92,14 @@ fn main() {
                 "participating": pk_refs.len(),
                 "signing_root": bytes_to_hex(&signing_root)
             }));
+            Ok(())
         },
         _ => {
             println!("{}", serde_json::json!({
                 "verified": false,
                 "error": format!("{:?}", result)
             }));
+            Ok(())
         }
     }
 }
@@ -124,11 +133,15 @@ fn sha256(data: &[u8]) -> Vec<u8> {
     hasher.finalize().to_vec()
 }
 
-fn hex_to_bytes(hex: &str) -> Vec<u8> {
+fn hex_to_bytes(hex: &str) -> Result<Vec<u8>, CliError> {
     let hex = hex.trim_start_matches("0x");
+    if !hex.len().is_multiple_of(2) {
+        return Err(format!("hex string has odd length: {}", hex.len()).into());
+    }
     (0..hex.len())
         .step_by(2)
-        .map(|i| u8::from_str_radix(&hex[i..i+2], 16).unwrap())
+        .map(|i| u8::from_str_radix(&hex[i..i+2], 16)
+            .map_err(|e| format!("invalid hex at byte {}: {e}", i / 2).into()))
         .collect()
 }
 


### PR DESCRIPTION
## Summary

Two clippy-flagged findings from an external audit:

### bls-verifier FFI safety (`bls-verifier/src/lib.rs`)
- `verify_sync_committee` was `pub extern "C" fn` while dereferencing raw pointers — clippy `not_unsafe_ptr_arg_deref`. Changed to `pub unsafe extern "C" fn` with a `# Safety` doc-comment documenting the FFI pointer-validity contract.
- Added defensive null-pointer checks before `from_raw_parts`. Null `sig_ptr` / `signing_root_ptr` returns `-1`; null `pubkeys_ptr` or zero `pubkeys_len` returns `-2`. Matches the existing return-code contract.

### bls-verify-cli panic handling (`bls-verify-cli/src/main.rs`)
- Replaced `.unwrap()` chains with a `Result`-returning `run()` function. Garbage stdin, missing fields, malformed hex, and odd-length hex strings now produce a clean stderr message + JSON error doc on stdout, and the process exits `1` instead of panicking with a Rust backtrace.
- `require_str` / `require_array` helpers replace `.as_str().unwrap()` / `.as_array().unwrap()` with field-named errors.

## Verification

- `cargo check --workspace --all-targets`: clean
- `cargo test --workspace`: passes (no regressions)
- `cargo clippy -p bls-verifier --all-targets -- -D warnings`: clean
- `cargo clippy -p bls-verify-cli --all-targets -- -D warnings`: clean
- Manual exit-code probe: garbage / empty / missing-field stdin all produce JSON error + exit 1 (was: panic + exit 101)

## Compatibility

No behavior change on valid input. The FFI return-code semantics are preserved verbatim per O-700 / W.01. C callers that previously called `verify_sync_committee` from `unsafe { ... }` blocks (which is required by the C ABI anyway) continue to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
