### PR TITLE
fix #4: index-map validators-by-id response (closes S.02 verified=false)

### DIFF
--- a/bls-device/src/beacon.rs
+++ b/bls-device/src/beacon.rs
@@ -89,8 +89,14 @@ impl BeaconClient for HttpBeaconClient {
             .filter_map(|v| v.as_str().map(str::to_string))
             .collect();
 
-        let mut pubkeys: Vec<[u8; 48]> = Vec::with_capacity(indices.len());
-        // Mirrors the chunks-of-10 pattern from bls-test/src/main.rs:64
+        // Beacon API `/validators?id=...` re-sorts the response by validator
+        // index ascending — the response order does NOT match the request
+        // order. We MUST reassemble in `indices` order; otherwise the sync
+        // committee bitfield positions get mismapped to the wrong pubkeys
+        // and BLS verification fails downstream. (Issue #4 root cause.)
+        let mut by_index: std::collections::HashMap<String, [u8; 48]> =
+            std::collections::HashMap::with_capacity(indices.len());
+        // Chunked to respect URL-length limits at ~10 ids per query.
         for chunk in indices.chunks(10) {
             let query: String = chunk
                 .iter()
@@ -102,18 +108,34 @@ impl BeaconClient for HttpBeaconClient {
                 .await?;
             if let Some(validators) = resp["data"].as_array() {
                 for v in validators {
+                    let idx = v["index"]
+                        .as_str()
+                        .ok_or_else(|| {
+                            DeviceError::BeaconExhausted("validator missing index".into())
+                        })?
+                        .to_string();
                     if let Some(s) = v["validator"]["pubkey"].as_str() {
                         let bytes = hex::decode(s.trim_start_matches("0x"))
                             .map_err(|e| DeviceError::BeaconExhausted(format!("bad pubkey: {e}")))?;
                         if bytes.len() == 48 {
                             let mut pk = [0u8; 48];
                             pk.copy_from_slice(&bytes);
-                            pubkeys.push(pk);
+                            by_index.insert(idx, pk);
                         }
                     }
                 }
             }
         }
+
+        // Reassemble in sync-committee position order (the order of `indices`).
+        let pubkeys: Vec<[u8; 48]> = indices
+            .iter()
+            .map(|i| {
+                by_index.get(i).copied().ok_or_else(|| {
+                    DeviceError::BeaconExhausted(format!("validator {i} missing from response"))
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
         Ok(pubkeys)
     }
 }

--- a/bls-test/src/main.rs
+++ b/bls-test/src/main.rs
@@ -59,7 +59,13 @@ async fn main() {
 
     // Step 4: fetch all pubkeys in batches of 10
     println!("Fetching pubkeys...");
-    let mut all_pubkeys: Vec<PublicKey> = vec![];
+    // Beacon API `/validators?id=...` re-sorts the response by validator
+    // index ascending — the response order does NOT match the request
+    // order. Build an index→pubkey map, then reassemble in `indices` order.
+    // Without this, sync committee bitfield positions get mismapped to the
+    // wrong pubkeys and BLS verification fails. (Issue #4 root cause.)
+    use std::collections::HashMap;
+    let mut by_index: HashMap<String, PublicKey> = HashMap::with_capacity(indices.len());
 
     for chunk in indices.chunks(10) {
         let query: String = chunk.iter()
@@ -77,14 +83,21 @@ async fn main() {
 
         if let Some(validators) = resp["data"].as_array() {
             for v in validators {
+                let idx = v["index"].as_str().unwrap_or("").to_string();
                 let pubkey_hex = v["validator"]["pubkey"].as_str().unwrap_or("");
                 let bytes = hex_to_bytes(pubkey_hex);
                 if let Ok(pk) = PublicKey::from_bytes(&bytes) {
-                    all_pubkeys.push(pk);
+                    by_index.insert(idx, pk);
                 }
             }
         }
     }
+
+    // Reassemble in sync-committee position order.
+    let all_pubkeys: Vec<PublicKey> = indices
+        .iter()
+        .filter_map(|i| by_index.get(i).cloned())
+        .collect();
     println!("Total pubkeys fetched: {}", all_pubkeys.len());
 
     // Step 5: filter pubkeys by participation bits


### PR DESCRIPTION
## Summary

Closes #4. The S.02 `verified=false` bug had a single root cause: the validators-by-id batch fetch silently re-sorts the response.

## Root cause

`GET /eth/v1/beacon/states/head/validators?id=A&id=B&id=C` returns the response **sorted by validator index ascending**, NOT in the order of the `id=` query parameters. (Confirmed empirically against `ethereum-beacon-api.publicnode.com` — request `id=2194937&id=334828&id=1857386`, response order `[334828, 1857386, 2194937]`.)

When the 512 sync committee pubkeys are fetched in chunks of 10 and pushed in iteration order, `all_pubkeys[i]` ends up holding the validator at the **lowest** committee-position in chunk `i//10` — NOT the validator at sync committee position `i`.

The bitfield filter then maps bit `i` → wrong pubkey, the aggregate combines the wrong subset, and the BLS verify cleanly returns `primitive_return_code=0` (sig invalid).

The math (`compute_domain`, `compute_signing_root`, parent_root as signing target, DST string, blst aggregation) was all correct from the start. Only the pubkey-position mapping was broken.

## Fix

Build `HashMap<String, Pubkey>` keyed by validator index while iterating the API response, then reassemble the final `Vec` by iterating the original `indices` order from `/sync_committees`. This preserves the position→pubkey mapping the bitfield expects.

Both `bls-device/src/beacon.rs::committee_pubkeys` and `bls-test/src/main.rs` had the same bug; both fixed in this commit.

## Verification

- **bls-test against current mainnet head** (via publicnode.com):
  ```
  Slot: 14245514
  Participating validators: 510
  Fork version: 0x06000000
  SIGNATURE VALID - Paxiom verified Ethereum consensus!
  ```
- **bls-device-harness via paxiom services/sync-committee end-to-end** (slot 14245526):
  ```json
  {
    "verified": true,
    "primitive_return_code": 1,
    "participating": 510,
    "committee_size": 512,
    ...
  }
  ```
  Evidence file: `paxiom/hyperbeam/bringup/evidence/gate-s02-20260503T010547Z.json`

## Operator note

Operators with a populated `SqliteCommitteeCache` from before this fix **must clear it once**:
```bash
rm ~/.cache/bls-device-harness/committees.sqlite
# or whatever $BLS_DEVICE_CACHE_PATH points at
```
Stale wrong-order pubkeys cached under a period key will continue to produce `verified=false` until evicted.

## Test plan

- [ ] CI green
- [ ] Operator re-runs S.02 evidence flow after merging — should print `verified: true` with `primitive_return_code: 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
