### PR TITLE
fix(audit/C-1+C-2): filter_participating validates SSZ Bitvector[512] invariants

### DIFF
--- a/bls-device/src/lib.rs
+++ b/bls-device/src/lib.rs
@@ -43,6 +43,12 @@ pub const MAINNET_GENESIS_VALIDATORS_ROOT: [u8; 32] = [
 /// Number of slots per sync committee period (256 epochs * 32 slots).
 pub const SLOTS_PER_PERIOD: u64 = 8192;
 
+/// Sync-committee size per the consensus spec (`SYNC_COMMITTEE_SIZE`).
+pub const SYNC_COMMITTEE_SIZE: usize = 512;
+
+/// Bytes of `Bitvector[SYNC_COMMITTEE_SIZE]` participation bits (= 64).
+pub const SYNC_COMMITTEE_BITS_BYTES: usize = SYNC_COMMITTEE_SIZE / 8;
+
 /// Public request schema (O-701 / S.02).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct VerifyRequest {
@@ -148,6 +154,15 @@ impl Device {
             .map_err(|e| DeviceError::InvalidRequest(format!("slot parse: {e}")))?;
         let parent_root = decode_hex_fixed::<32>(&req.parent_root, "parent_root")?;
         let bits = decode_hex(&req.sync_aggregate.sync_committee_bits)?;
+        // SSZ `Bitvector[SYNC_COMMITTEE_SIZE]` is exactly 64 bytes. Reject
+        // truncated/oversize bitfields up front so a malformed input cannot
+        // silently pick an arbitrary subset of the cached committee.
+        if bits.len() != SYNC_COMMITTEE_BITS_BYTES {
+            return Err(DeviceError::InvalidRequest(format!(
+                "sync_committee_bits: expected {SYNC_COMMITTEE_BITS_BYTES} bytes, got {}",
+                bits.len()
+            )));
+        }
         let signature = decode_hex_fixed::<96>(&req.sync_aggregate.sync_committee_signature, "sig")?;
 
         // Stage 2: x402 verify (stub if mock).
@@ -171,6 +186,16 @@ impl Device {
                 fetched
             }
         };
+        // Refuse a committee of any size other than the spec-mandated 512.
+        // A truncated beacon response would otherwise yield committee_size
+        // < 512 and still verify against a partial-aggregate signature,
+        // which is exactly what an attacker wants.
+        if pubkeys.len() != SYNC_COMMITTEE_SIZE {
+            return Err(DeviceError::InvalidRequest(format!(
+                "committee size: expected {SYNC_COMMITTEE_SIZE} pubkeys, got {}",
+                pubkeys.len()
+            )));
+        }
         let committee_size = pubkeys.len() as u32;
 
         // Stage 5: filter by participation bits.
@@ -225,6 +250,18 @@ impl Device {
     }
 }
 
+/// Pick the subset of `pubkeys` whose corresponding bit in `bits` is set.
+///
+/// SSZ `Bitvector[N]` is encoded little-endian within a byte: bit 0 of
+/// byte 0 is participant 0; bit 7 of byte 0 is participant 7; bit 0 of
+/// byte 1 is participant 8. The shift `bits[byte_idx] >> bit_idx`
+/// reflects that LSB-first convention. Do not flip to MSB-first without
+/// also flipping every Ethereum consensus-client interop fixture.
+///
+/// The caller is responsible for asserting `pubkeys.len() ==
+/// SYNC_COMMITTEE_SIZE` and `bits.len() == SYNC_COMMITTEE_BITS_BYTES`.
+/// `Device::verify` does this; the helper itself stays generic so unit
+/// tests can exercise smaller arrays.
 fn filter_participating<'a>(pubkeys: &'a [[u8; 48]], bits: &[u8]) -> Vec<&'a [u8; 48]> {
     pubkeys
         .iter()
@@ -294,6 +331,24 @@ mod tests {
         assert_eq!(out.len(), 2);
         assert_eq!(out[0], &[1u8; 48]);
         assert_eq!(out[1], &[3u8; 48]);
+    }
+
+    #[test]
+    fn filter_participating_lsb_first_byte_order() {
+        // Eight pubkeys, each labelled by index. Bits 0, 3, 7 of byte 0 set,
+        // and bit 0 of byte 1 set: expect indices 0, 3, 7, 8.
+        let pubkeys: Vec<[u8; 48]> = (0..16u8).map(|i| [i; 48]).collect();
+        let bits = vec![0b1000_1001, 0b0000_0001];
+        let out = filter_participating(&pubkeys, &bits);
+        let got_idx: Vec<u8> = out.into_iter().map(|pk| pk[0]).collect();
+        assert_eq!(got_idx, vec![0, 3, 7, 8]);
+    }
+
+    #[test]
+    fn sync_committee_constants_are_consistent() {
+        assert_eq!(SYNC_COMMITTEE_SIZE, 512);
+        assert_eq!(SYNC_COMMITTEE_BITS_BYTES, 64);
+        assert_eq!(SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_BITS_BYTES * 8);
     }
 
     #[test]


### PR DESCRIPTION
## Audit findings

`AUDIT_REPORT.md` **C-1** and **C-2** (Critical, co-located) — _`filter_participating` does not validate bitfield length against committee size_, and _Bit-iteration order is not validated as SSZ `Bitvector[512]` order_.

## What this PR does

Two co-located findings in `bls-device/src/lib.rs::filter_participating`:

- **C-1**: bitfield length never validated against committee size. A truncated or oversize `sync_committee_bits` silently filtered using whatever bits were available — including returning an empty participating set on a 0-byte bits string.
- **C-2**: bit-iteration order matched SSZ `Bitvector[N]`'s LSB-first byte convention only by accident; no comment or test asserted it, so a future refactor flipping to MSB-first would not break any test.

### Changes (`bls-device/src/lib.rs`)

1. **New public constants**:
   ```rust
   pub const SYNC_COMMITTEE_SIZE: usize = 512;
   pub const SYNC_COMMITTEE_BITS_BYTES: usize = SYNC_COMMITTEE_SIZE / 8; // 64
   ```

2. **`Device::verify` invariants**:
   - Up-front: rejects `bits.len() != 64` with `InvalidRequest`, closing the silent partial-aggregate path.
   - After committee fetch: rejects `pubkeys.len() != 512` to refuse a truncated beacon's partial committee. Per O-700 / W.01 the harness is required to enforce committee length 512; this code now does.

3. **`filter_participating` doc-comment**: explicitly cites SSZ `Bitvector[N]` LSB-first byte order with a "do not flip" note pointing at every Ethereum interop fixture. The function does not assert lengths itself so smaller-array unit tests still work.

4. **New tests**:
   - `filter_participating_lsb_first_byte_order` — regression that catches an accidental MSB-flip by computing participants for a hand-tuned bit pattern across two bytes (bits 0/3/7 of byte 0 and bit 0 of byte 1 → indices 0/3/7/8).
   - `sync_committee_constants_are_consistent` — the two constants stay in sync as the codebase evolves.

## Tests

```
$ cargo test -p bls-device --lib
running 7 tests
test signing_root::tests::domain_changes_with_fork_version ... ok
test tests::filter_participating_lsb_first_byte_order ... ok
test tests::filter_participating_picks_only_set_bits ... ok
test signing_root::tests::signing_root_is_deterministic ... ok
test tests::sync_committee_constants_are_consistent ... ok
test tests::hash_request_is_deterministic ... ok
test cache::tests::put_get_roundtrip ... ok
test result: ok. 7 passed
```

Refs: AUDIT_REPORT.md — C-1, C-2.

---
_Generated by [Claude Code](https://claude.ai/code/session_011pVUYF6xPPuiQf2zYiSxuk)_