### PR TITLE
fix(audit/C-3): committee_pubkeys queries the slot's state, not head

### DIFF
--- a/bls-device/src/beacon.rs
+++ b/bls-device/src/beacon.rs
@@ -97,8 +97,13 @@ impl BeaconClient for HttpBeaconClient {
                 .map(|id| format!("id={id}"))
                 .collect::<Vec<_>>()
                 .join("&");
+            // Resolve validator pubkeys against the request's slot, not
+            // `head`. On a validator-key rotation or exit between the slot
+            // of interest and `head`, querying `head` returns the wrong
+            // pubkey set and the cache pins the wrong-but-self-consistent
+            // committee under the period key.
             let resp = self
-                .get_json(&format!("/eth/v1/beacon/states/head/validators?{query}"))
+                .get_json(&format!("/eth/v1/beacon/states/{slot}/validators?{query}"))
                 .await?;
             if let Some(validators) = resp["data"].as_array() {
                 for v in validators {


### PR DESCRIPTION
## Audit finding

`AUDIT_REPORT.md` **C-3** (Critical) — _`committee_pubkeys` resolves validator pubkeys against `head`, not the request's slot/period; under validator-key rotation the cached committee binds the wrong pubkeys to a period_.

## What this PR does

Before this change, `committee_pubkeys` (`bls-device/src/beacon.rs:81-118`) read sync committee indices from `/eth/v1/beacon/states/{slot}/sync_committees` (correctly slot-scoped) but then resolved each validator's pubkey via `/eth/v1/beacon/states/head/validators?id=...` — against `head`, not the slot's state.

Under any validator-key rotation or exit between the slot of interest and `head`, the cached "committee" would be wrong. The cache then pinned the wrong-but-self-consistent set of pubkeys under the period key, so every subsequent lookup for that period returned the same wrong data. A signature signed by the slot's actual committee would then fail to verify against the head-derived pubkey set.

### Change

```diff
- /eth/v1/beacon/states/head/validators?{query}
+ /eth/v1/beacon/states/{slot}/validators?{query}
```

The variable `slot` is already in scope.

## Sharp edge

Pruned beacon nodes return 404 for slots older than their retention. The `FailoverPool` already cycles endpoints, but operators who need historical committees should point at archive nodes.

## Out of scope

Related but separate (audit **H-6** / **M-9**): the cache row should also include `genesis_validators_root` in its key, so a Holesky / Hoodi / Mainnet operator switch cannot collide periods. That fix touches `cache.rs`'s schema and is its own diff.

The audit also recommended a unit test that asserts the URL includes the slot. Adding one requires either an HTTP mock framework (wiremock) or refactoring `committee_pubkeys` to take a URL builder — both are larger scope. The fixture-based integration test (`tests/integration_fixture.rs`) uses a `FixtureBeacon` mock that bypasses the URL entirely; it remains green.

## Tests

```
$ cargo test -p bls-device --lib
test result: ok. 5 passed; 0 failed
```

Refs: AUDIT_REPORT.md — C-3.

---
_Generated by [Claude Code](https://claude.ai/code/session_011pVUYF6xPPuiQf2zYiSxuk)_