### PR TITLE
fix(audit/L-7): remove dead _unused_marker fn from primitive.rs

### DIFF
--- a/bls-device/src/primitive.rs
+++ b/bls-device/src/primitive.rs
@@ -6,7 +6,7 @@
 //! in-process, and the wasm adapter is filed as a follow-up once HyperBEAM's
 //! device hosting interface is locked.
 
-use crate::{DeviceError, Result};
+use crate::Result;
 use blst::min_pk::{AggregatePublicKey, PublicKey, Signature};
 use blst::BLST_ERROR;
 
@@ -76,6 +76,3 @@ pub fn return_code_to_error_label(code: i32) -> Option<&'static str> {
         _ => Some("UnknownPrimitiveError"),
     }
 }
-
-#[allow(dead_code)]
-fn _unused_marker(_: DeviceError) {}


### PR DESCRIPTION
Closes #34. 5/5 implementers converged: drop `DeviceError` import (no other use in file) + remove the dead marker fn. `cargo build -p bls-device` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_011pVUYF6xPPuiQf2zYiSxuk)_