### PR TITLE
fix(audit/M-2 + M-8): -5 NoParticipants; checked period i64 cast

### DIFF
--- a/bls-device/src/cache.rs
+++ b/bls-device/src/cache.rs
@@ -59,12 +59,14 @@ impl SqliteCommitteeCache {
 #[async_trait]
 impl CommitteeCache for SqliteCommitteeCache {
     async fn get(&self, period: u64) -> Result<Option<Vec<[u8; 48]>>> {
+        let period_i64 = i64::try_from(period)
+            .map_err(|_| DeviceError::Cache(format!("period {period} overflows i64")))?;
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn
             .prepare("SELECT pubkeys FROM sync_committee WHERE period = ?1")
             .map_err(|e| DeviceError::Cache(e.to_string()))?;
         let row: rusqlite::Result<Vec<u8>> =
-            stmt.query_row(params![period as i64], |r| r.get(0));
+            stmt.query_row(params![period_i64], |r| r.get(0));
         match row {
             Ok(blob) => {
                 if blob.len() % 48 != 0 {
@@ -87,6 +89,8 @@ impl CommitteeCache for SqliteCommitteeCache {
     }
 
     async fn put(&self, period: u64, pubkeys: &[[u8; 48]]) -> Result<()> {
+        let period_i64 = i64::try_from(period)
+            .map_err(|_| DeviceError::Cache(format!("period {period} overflows i64")))?;
         let mut blob = Vec::with_capacity(pubkeys.len() * 48);
         for pk in pubkeys {
             blob.extend_from_slice(pk);
@@ -102,7 +106,7 @@ impl CommitteeCache for SqliteCommitteeCache {
         conn.execute(
             "INSERT OR REPLACE INTO sync_committee (period, pubkeys, fetched_at)
              VALUES (?1, ?2, ?3)",
-            params![period as i64, blob, now],
+            params![period_i64, blob, now],
         )
         .map_err(|e| DeviceError::Cache(e.to_string()))?;
         Ok(())

--- a/bls-device/src/primitive.rs
+++ b/bls-device/src/primitive.rs
@@ -18,6 +18,7 @@ pub trait Primitive: Send + Sync {
     ///  -2 = pubkey parse failure
     ///  -3 = aggregation failure
     ///  -4 = signing root is not 32 bytes
+    ///  -5 = empty participating set (caller bug, not a crypto failure)
     fn verify(
         &self,
         participating: &[&[u8; 48]],
@@ -38,7 +39,10 @@ impl Primitive for NativePrimitive {
         signing_root: &[u8; 32],
     ) -> Result<i32> {
         if participating.is_empty() {
-            return Ok(-3);
+            // Empty participating set is a caller-side bug (e.g. all-zero
+            // bitfield), not a real cryptographic aggregation failure.
+            // Return -5 so operators can distinguish the two paths.
+            return Ok(-5);
         }
         let pks: Vec<PublicKey> = participating
             .iter()
@@ -73,6 +77,7 @@ pub fn return_code_to_error_label(code: i32) -> Option<&'static str> {
         -2 => Some("PubkeyParseFailure"),
         -3 => Some("AggregationFailed"),
         -4 => Some("InvalidSigningRoot"),
+        -5 => Some("NoParticipants"),
         _ => Some("UnknownPrimitiveError"),
     }
 }


### PR DESCRIPTION
Closes #17 (M-2), #23 (M-8). Direct-apply.

Out of scope: M-1 (3-way return-code taxonomy unification across bls-verifier/lib.rs + primitive.rs + manifest.rs) — multi-crate refactor, separate PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_011pVUYF6xPPuiQf2zYiSxuk)_