### PR TITLE
fix(audit/H-1): feature-gate MockX402 + BLS_ALLOW_MOCK runtime floor

### DIFF
--- a/.github/workflows/bls-device.yml
+++ b/.github/workflows/bls-device.yml
@@ -31,7 +31,10 @@ jobs:
         run: cargo build --release --target wasm32-unknown-unknown -p bls-verifier
 
       - name: Workspace test
-        run: cargo test --workspace --no-fail-fast
+        # bls-device integration tests require the mock-x402 feature (issue #10);
+        # the default build deliberately excludes MockX402 to keep it out of release
+        # binaries.
+        run: cargo test --workspace --no-fail-fast --features bls-device/mock-x402
 
       - name: Upload wasm artifact for downstream consumers
         uses: actions/upload-artifact@v4

--- a/bls-device/Cargo.toml
+++ b/bls-device/Cargo.toml
@@ -28,3 +28,11 @@ uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = "3"
+
+[features]
+default = []
+# Compiles the always-Ok MockX402 verifier for integration tests.
+# A default release build does not include MockX402 — see issue #10.
+# Even with this feature on, Device::new requires BLS_ALLOW_MOCK=1
+# at process start.
+mock-x402 = []

--- a/bls-device/src/lib.rs
+++ b/bls-device/src/lib.rs
@@ -31,7 +31,9 @@ pub use crate::ao::{AoLogger, MockAo};
 pub use crate::beacon::{BeaconClient, FailoverPool};
 pub use crate::cache::{CommitteeCache, SqliteCommitteeCache};
 pub use crate::primitive::{NativePrimitive, Primitive};
-pub use crate::x402::{MockX402, X402Verifier};
+pub use crate::x402::X402Verifier;
+#[cfg(feature = "mock-x402")]
+pub use crate::x402::MockX402;
 
 /// Mainnet genesis_validators_root. Constant per network — embedded here as
 /// a per-deployment constant. A different chain id means a different deployment.
@@ -120,6 +122,12 @@ pub struct Device {
 }
 
 impl Device {
+    /// Construct a Device. When the `mock-x402` cargo feature is compiled
+    /// in, `BLS_ALLOW_MOCK=1` must be set in the environment or this
+    /// panics at construction. Mirrors paxiom's `PAXIOM_ALLOW_MOCK=1`
+    /// floor; intent is that misconfigured deployments fail loudly at
+    /// process start, not at request time. In a default release build
+    /// (`mock-x402` off) the check is a no-op.
     pub fn new(
         beacon: Arc<FailoverPool>,
         cache: Arc<dyn CommitteeCache>,
@@ -129,6 +137,19 @@ impl Device {
         genesis_validators_root: [u8; 32],
         platform_key_id: impl Into<String>,
     ) -> Self {
+        #[cfg(feature = "mock-x402")]
+        {
+            if std::env::var("BLS_ALLOW_MOCK").as_deref() != Ok("1") {
+                panic!(
+                    "bls-device built with `mock-x402` feature but \
+                     BLS_ALLOW_MOCK=1 not set; refusing to construct \
+                     Device (issue #10)"
+                );
+            }
+            tracing::warn!(
+                "bls-device running with `mock-x402` feature enabled (issue #10)"
+            );
+        }
         Self {
             beacon,
             cache,

--- a/bls-device/src/x402.rs
+++ b/bls-device/src/x402.rs
@@ -1,22 +1,47 @@
-//! O-701 / S.03 stage 2 — x402 verification stub.
+//! O-701 / S.03 stage 2 — x402 verification trait.
 //!
-//! Real implementation (Coinbase facilitator integration) lives in a future
-//! runbook. For Phase 0 the device runs with a mock that accepts any payload
-//! and returns a deterministic id derived from the request hash, so the
-//! pipeline shape is exercised end-to-end without a live facilitator.
+//! Real implementation (Coinbase facilitator integration) is tracked as a
+//! follow-up to issue #10. The facilitator schema is defined by Coinbase
+//! and MUST NOT be invented in this repo. For Phase 0 a mock is provided
+//! behind the `mock-x402` cargo feature for tests only.
 
 use async_trait::async_trait;
 
+/// x402 payment verification.
+///
+/// # Security contract (issue #10)
+///
+/// A production `X402Verifier` MUST authenticate the payload against the
+/// Coinbase x402 facilitator and return `Err` when the payment is missing,
+/// unsettled, replayed, or otherwise invalid. Implementations that
+/// unconditionally return `Ok` (such as `MockX402`) are a security
+/// violation outside of test code and must never be wired into a release
+/// `Device`. The trait itself cannot enforce this — operators and reviewers
+/// must. `Device::new` enforces a runtime floor when the `mock-x402`
+/// feature is compiled in.
 #[async_trait]
 pub trait X402Verifier: Send + Sync {
     async fn verify(&self, payload: &str, request_hash: &[u8; 32]) -> Result<String, String>;
 }
 
+/// Test-only verifier that accepts every payload. Gated behind the
+/// `mock-x402` cargo feature so it cannot be named from a default
+/// release build. Every accept is logged at WARN so a misconfigured
+/// staging deploy is observable in logs.
+#[cfg(feature = "mock-x402")]
 pub struct MockX402;
 
+#[cfg(feature = "mock-x402")]
 #[async_trait]
 impl X402Verifier for MockX402 {
     async fn verify(&self, _payload: &str, request_hash: &[u8; 32]) -> Result<String, String> {
-        Ok(format!("mock-{}", hex::encode(&request_hash[..8])))
+        let id = format!("mock-{}", hex::encode(&request_hash[..8]));
+        tracing::warn!(
+            target: "bls_device::x402",
+            id = %id,
+            "MockX402 accepting payload without facilitator check (issue #10); \
+             this MUST NOT appear in production logs"
+        );
+        Ok(id)
     }
 }

--- a/bls-device/tests/integration_fixture.rs
+++ b/bls-device/tests/integration_fixture.rs
@@ -111,6 +111,7 @@ fn fixture_slot(fixture_dir: &PathBuf) -> u64 {
 
 #[tokio::test]
 async fn pipeline_runs_end_to_end_against_fixture() {
+    std::env::set_var("BLS_ALLOW_MOCK", "1");
     let fixture_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()

--- a/bls-device/tests/integration_live.rs
+++ b/bls-device/tests/integration_live.rs
@@ -19,6 +19,7 @@ async fn live_lodestar_verifies_current_head() {
         eprintln!("BLS_DEVICE_LIVE not set; skipping live test");
         return;
     }
+    std::env::set_var("BLS_ALLOW_MOCK", "1");
 
     let endpoints = vec![(
         "lodestar".to_string(),


### PR DESCRIPTION
## Summary

Resolves audit finding **H-1** (issue #10): `MockX402` always returns `Ok`; `Device::new` does not require a non-mock impl in production builds.

## Decision (7-agent panel)

5 implementers split between cfg-gate-only, cfg-gate + invented HttpX402, runtime env-gate, and minimalist-debug-assert. The asshole returned "neither side made the case": cfg-gating doesn't constrain the trait (downstream `AlwaysOk` reproduces the bug), HttpX402 proposals invented a Coinbase facilitator schema that doesn't live in this repo, and `debug_assert!` is stripped in `--release`.

Final synthesis: defense-in-depth without inventing API the audit didn't mandate.

## Changes

1. **`bls-device` cargo feature `mock-x402`** (default off). `MockX402` is gated behind it; default release builds physically cannot name the symbol.
2. **Runtime `BLS_ALLOW_MOCK=1` check at `Device::new`**, fires only when `mock-x402` is compiled in. Mirrors paxiom's `PAXIOM_ALLOW_MOCK=1` floor — misconfigured deployments fail at process start, not at request time.
3. **`tracing::warn!` in `MockX402::verify`** so any misconfigured staging logs every accept.
4. **`X402Verifier` trait doc** makes the security contract explicit: production impls MUST authenticate via the Coinbase facilitator; always-Ok impls are violations.
5. **CI updated** to `cargo test --workspace --features bls-device/mock-x402`.
6. **Test fixtures** set `BLS_ALLOW_MOCK=1` inline.

## What this does NOT do

No `HttpX402` client. The Coinbase x402 facilitator schema is defined externally and must not be invented under audit-PR pressure. Filed as a follow-up issue.

The trait hole (any `Arc<dyn X402Verifier>` is structurally accepted) is fundamental to the trait abstraction. The cfg-gate + runtime floor + loud doc-comment are the correct defense-in-depth without inventing trait surgery.

## Verification

```
$ cargo build -p bls-device                                    # clean (no mock symbol)
$ cargo build -p bls-device --features mock-x402              # clean (mock available)
$ cargo test -p bls-device --test integration_fixture --no-run # FAILS (correct, mock gated)
$ cargo test --workspace --no-fail-fast --features bls-device/mock-x402
test result: ok. 7 passed (lib)
test result: ok. 1 passed (integration_fixture)
```

## Test plan

- [x] Default `cargo build` does not link MockX402
- [x] `cargo build --features mock-x402` compiles
- [x] Default `cargo test --test integration_fixture` fails-to-compile (correct: mock gated)
- [x] `cargo test --features mock-x402` passes
- [x] CI workflow runs with the feature enabled

Closes #10.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbpkZghhSLT3rSSvNFd1bV)_