### PR TITLE
fix(audit/H-2): mandatory ed25519 sign_response, replace SHA-256 stub

### DIFF
--- a/bls-device/Cargo.toml
+++ b/bls-device/Cargo.toml
@@ -25,6 +25,8 @@ async-trait = "0.1"
 thiserror = "1"
 tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
+ed25519-dalek = { version = "2", features = ["pkcs8", "pem", "rand_core"] }
+rand = "0.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/bls-device/src/lib.rs
+++ b/bls-device/src/lib.rs
@@ -107,7 +107,7 @@ pub enum DeviceError {
 pub type Result<T> = std::result::Result<T, DeviceError>;
 
 /// Owns all O-701 device state: beacon pool, committee cache, primitive runner,
-/// x402 verifier, AO logger, and platform signing key id.
+/// x402 verifier, AO logger, and the platform signing key.
 ///
 /// One instance per HyperBEAM device process. Construct at startup; reuse for
 /// the process lifetime.
@@ -119,6 +119,10 @@ pub struct Device {
     pub ao: Arc<dyn AoLogger>,
     pub genesis_validators_root: [u8; 32],
     pub platform_key_id: String,
+    /// ed25519 signing key for the response envelope. Required since audit
+    /// H-2 (#11): the prior SHA-256 stub was forgeable from public response
+    /// data. Real TEE binding is tracked as O-720 follow-up.
+    pub signing_key: ed25519_dalek::SigningKey,
 }
 
 impl Device {
@@ -136,6 +140,7 @@ impl Device {
         ao: Arc<dyn AoLogger>,
         genesis_validators_root: [u8; 32],
         platform_key_id: impl Into<String>,
+        signing_key: ed25519_dalek::SigningKey,
     ) -> Self {
         #[cfg(feature = "mock-x402")]
         {
@@ -158,6 +163,7 @@ impl Device {
             ao,
             genesis_validators_root,
             platform_key_id: platform_key_id.into(),
+            signing_key,
         }
     }
 
@@ -236,7 +242,7 @@ impl Device {
 
         // Stage 8: sign response + AO log.
         let platform_signature =
-            sign_response(&self.platform_key_id, &signing_root, verified);
+            sign_response(&self.signing_key, &signing_root, verified);
         let ao_message_id = self
             .ao
             .log(&ao::ComplianceEvent {
@@ -311,15 +317,20 @@ fn hash_request(req: &VerifyRequest) -> [u8; 32] {
     h.finalize().into()
 }
 
-/// Stub platform signature: SHA-256 over (key_id || signing_root || verified-byte).
-/// Real implementation lives in O-720 (TEE-bound key rotation runbook).
-fn sign_response(key_id: &str, signing_root: &[u8; 32], verified: bool) -> [u8; 32] {
-    use sha2::{Digest, Sha256};
-    let mut h = Sha256::new();
-    h.update(key_id.as_bytes());
-    h.update(signing_root);
-    h.update([verified as u8]);
-    h.finalize().into()
+/// Platform signature: ed25519 over (signing_root || verified-byte).
+///
+/// Audit H-2 (#11): the prior SHA-256 stub was forgeable from public
+/// response data. Real TEE binding is tracked as O-720 follow-up.
+fn sign_response(
+    signing_key: &ed25519_dalek::SigningKey,
+    signing_root: &[u8; 32],
+    verified: bool,
+) -> [u8; 64] {
+    use ed25519_dalek::Signer;
+    let mut msg = [0u8; 33];
+    msg[..32].copy_from_slice(signing_root);
+    msg[32] = verified as u8;
+    signing_key.sign(&msg).to_bytes()
 }
 
 fn decode_hex(s: &str) -> Result<Vec<u8>> {

--- a/bls-device/tests/integration_fixture.rs
+++ b/bls-device/tests/integration_fixture.rs
@@ -129,6 +129,7 @@ async fn pipeline_runs_end_to_end_against_fixture() {
         Box::new(FixtureBeacon::new(fixture_dir.clone(), slot));
     let pool = Arc::new(FailoverPool::new(vec![beacon], vec!["fixture".into()]));
     let cache = Arc::new(SqliteCommitteeCache::open_in_memory().unwrap());
+    let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
     let device = Device::new(
         pool,
         cache.clone(),
@@ -137,6 +138,7 @@ async fn pipeline_runs_end_to_end_against_fixture() {
         Arc::new(MockAo),
         MAINNET_GENESIS_VALIDATORS_ROOT,
         "test-key-1",
+        signing_key,
     );
 
     let req = fixture_request(&fixture_dir, slot);
@@ -146,7 +148,9 @@ async fn pipeline_runs_end_to_end_against_fixture() {
     assert_eq!(resp1.service, "A-202");
     assert_eq!(resp1.slot, slot.to_string());
     assert!(resp1.committee_size > 0);
+    // ed25519 signature is 64 bytes = 128 hex chars after the "0x" prefix.
     assert!(resp1.platform_signature.starts_with("0x"));
+    assert_eq!(resp1.platform_signature.len(), 2 + 128);
     assert!(resp1.ao_message_id.starts_with("mock-ao-"));
 
     // Second call exercises the cache hit path.

--- a/bls-device/tests/integration_live.rs
+++ b/bls-device/tests/integration_live.rs
@@ -68,6 +68,7 @@ async fn live_lodestar_verifies_current_head() {
         },
     };
 
+    let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
     let device = Device::new(
         pool,
         cache,
@@ -76,6 +77,7 @@ async fn live_lodestar_verifies_current_head() {
         Arc::new(MockAo),
         MAINNET_GENESIS_VALIDATORS_ROOT,
         "live-test-key",
+        signing_key,
     );
 
     let resp = device.verify(req, None).await.expect("device.verify");


### PR DESCRIPTION
## Summary

Resolves bls-verifier **H-2** (issue #11). Replaces the forgeable SHA-256 stub `sign_response` with mandatory ed25519 signing, mirroring paxiom H-01 PR #97.

## Why ed25519-dalek over blst

`blst` is in this crate to verify BLS12-381 sync-committee aggregates — a different concern from signing the device's own attestation. Mixing them invites a custom DST string nobody can cite a spec for. ed25519 gives 64-byte sigs (vs 96+), faster sign/verify, and operators mint keys with stock openssl.

## Changes

- `ed25519-dalek = "2"` + `rand = "0.8"` deps.
- `Device::signing_key: SigningKey` field, set at construction.
- `sign_response` signs `signing_root || verified-byte`, returns `[u8; 64]`.
- Integration fixtures use `SigningKey::generate`.
- Test asserts 128-hex-char signature.

## Verification

```
$ cargo build -p bls-device           # clean
$ cargo test -p bls-device --features mock-x402 --lib            # 7 passed
$ cargo test -p bls-device --features mock-x402 --test integration_fixture  # 1 passed
```

## Follow-up

TEE-bound key rotation (O-720) tracked separately. Operator UI for key management is sibling of paxiom #98.

Closes #11.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbpkZghhSLT3rSSvNFd1bV)_