### PR TITLE
H1.3: land HttpX402 production client follow-up

### DIFF
--- a/bls-device/Cargo.toml
+++ b/bls-device/Cargo.toml
@@ -30,6 +30,7 @@ rand = "0.8"
 
 [dev-dependencies]
 tempfile = "3"
+wiremock = "0.6"
 
 [features]
 default = []

--- a/bls-device/src/lib.rs
+++ b/bls-device/src/lib.rs
@@ -31,7 +31,7 @@ pub use crate::ao::{AoLogger, MockAo};
 pub use crate::beacon::{BeaconClient, FailoverPool};
 pub use crate::cache::{CommitteeCache, SqliteCommitteeCache};
 pub use crate::primitive::{NativePrimitive, Primitive};
-pub use crate::x402::X402Verifier;
+pub use crate::x402::{HttpX402, X402Verifier};
 #[cfg(feature = "mock-x402")]
 pub use crate::x402::MockX402;
 

--- a/bls-device/src/x402.rs
+++ b/bls-device/src/x402.rs
@@ -1,24 +1,38 @@
 //! O-701 / S.03 stage 2 — x402 verification trait.
 //!
-//! Real implementation (Coinbase facilitator integration) is tracked as a
-//! follow-up to issue #10. The facilitator schema is defined by Coinbase
-//! and MUST NOT be invented in this repo. For Phase 0 a mock is provided
-//! behind the `mock-x402` cargo feature for tests only.
+//! Phase 0 ships a feature-gated `MockX402` for tests and `HttpX402`, a
+//! production client over the canonical x402 facilitator `/verify`
+//! endpoint. The HTTP contract is defined by the open x402 spec
+//! (coinbase/x402, specs/x402-specification-v1.md) and the operator
+//! configures the URL/bearer to point at whichever facilitator they
+//! trust — typically Coinbase's hosted endpoint at
+//! `https://api.cdp.coinbase.com/platform/v2/x402/verify`.
 
 use async_trait::async_trait;
+use serde::Deserialize;
+use std::time::Duration;
 
 /// x402 payment verification.
 ///
 /// # Security contract (issue #10)
 ///
-/// A production `X402Verifier` MUST authenticate the payload against the
-/// Coinbase x402 facilitator and return `Err` when the payment is missing,
+/// A production `X402Verifier` MUST authenticate the payload against an
+/// x402 facilitator and return `Err` when the payment is missing,
 /// unsettled, replayed, or otherwise invalid. Implementations that
 /// unconditionally return `Ok` (such as `MockX402`) are a security
 /// violation outside of test code and must never be wired into a release
 /// `Device`. The trait itself cannot enforce this — operators and reviewers
 /// must. `Device::new` enforces a runtime floor when the `mock-x402`
 /// feature is compiled in.
+///
+/// # Payload framing
+///
+/// `payload` is forwarded verbatim to the facilitator request body. The
+/// caller is responsible for encoding it as the canonical x402
+/// `{ x402Version, paymentPayload, paymentRequirements }` JSON envelope;
+/// the verifier does not inspect the schema. This keeps the trait
+/// scheme-agnostic so future scheme evolutions (v2, alternative
+/// facilitators) do not require touching this module.
 #[async_trait]
 pub trait X402Verifier: Send + Sync {
     async fn verify(&self, payload: &str, request_hash: &[u8; 32]) -> Result<String, String>;
@@ -43,5 +57,299 @@ impl X402Verifier for MockX402 {
              this MUST NOT appear in production logs"
         );
         Ok(id)
+    }
+}
+
+/// Default request timeout for the production facilitator client.
+///
+/// 10 seconds matches the `maxTimeoutSeconds` upper bound observed in the
+/// canonical x402 example payloads (60s) divided by a comfortable
+/// settlement-vs-verify margin. The operator can override via
+/// `HttpX402::with_config`.
+const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Production x402 facilitator client.
+///
+/// Schema reference: `coinbase/x402` repo, `specs/x402-specification-v1.md`.
+/// Endpoint shape:
+///
+///   POST <facilitator_url>
+///   Authorization: Bearer <token>
+///   Content-Type: application/json
+///   Body: { x402Version, paymentPayload, paymentRequirements }
+///
+///   200 OK + { "isValid": true,  "payer": "0x..." }            → success
+///   200 OK + { "isValid": false, "invalidReason": "...", ... }  → failure
+///
+/// Note: the original audit follow-up wording (#45) referred to a
+/// `payment_id` success field. The current canonical x402 verify response
+/// has no such field; the documented success identifier is `payer`. The
+/// trait's `Result<String, String>` therefore returns `payer` on success.
+pub struct HttpX402 {
+    facilitator_url: String,
+    bearer: String,
+    http: reqwest::Client,
+}
+
+impl HttpX402 {
+    /// Build a client with the default 10s timeout.
+    pub fn new(facilitator_url: String, bearer: String) -> Result<Self, String> {
+        Self::with_config(facilitator_url, bearer, DEFAULT_HTTP_TIMEOUT)
+    }
+
+    /// Build a client with an explicit request timeout. Used by tests; an
+    /// operator can call this if the default 10s is unsuitable for their
+    /// facilitator's settlement latency.
+    pub fn with_config(
+        facilitator_url: String,
+        bearer: String,
+        timeout: Duration,
+    ) -> Result<Self, String> {
+        if facilitator_url.is_empty() {
+            return Err("facilitator_url required".into());
+        }
+        if bearer.is_empty() {
+            return Err("bearer auth token required".into());
+        }
+        let http = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .map_err(|e| format!("http client build: {e}"))?;
+        Ok(Self { facilitator_url, bearer, http })
+    }
+
+    /// Build a client from environment variables. Both must be set or
+    /// `Device` bringup fails closed.
+    ///
+    /// - `BLS_X402_FACILITATOR_URL` (e.g. `https://api.cdp.coinbase.com/platform/v2/x402/verify`)
+    /// - `BLS_X402_BEARER`          (Bearer token issued by the facilitator)
+    pub fn from_env() -> Result<Self, String> {
+        let url = std::env::var("BLS_X402_FACILITATOR_URL")
+            .map_err(|_| "BLS_X402_FACILITATOR_URL not set".to_string())?;
+        let bearer = std::env::var("BLS_X402_BEARER")
+            .map_err(|_| "BLS_X402_BEARER not set".to_string())?;
+        Self::new(url, bearer)
+    }
+}
+
+/// Subset of the canonical x402 verify response we deserialise. Unknown
+/// fields are ignored so the facilitator can add fields without breaking
+/// us.
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct VerifyResponseBody {
+    is_valid: bool,
+    payer: Option<String>,
+    invalid_reason: Option<String>,
+    invalid_message: Option<String>,
+}
+
+#[async_trait]
+impl X402Verifier for HttpX402 {
+    async fn verify(&self, payload: &str, _request_hash: &[u8; 32]) -> Result<String, String> {
+        let resp = self
+            .http
+            .post(&self.facilitator_url)
+            .header("Authorization", format!("Bearer {}", self.bearer))
+            .header("Content-Type", "application/json")
+            .body(payload.to_string())
+            .send()
+            .await
+            .map_err(|e| format!("x402 facilitator unreachable: {e}"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            // Best-effort body capture for the operator log; never trust
+            // it as a payment receipt.
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!(
+                "x402 facilitator non-2xx ({status}): {}",
+                body.chars().take(200).collect::<String>()
+            ));
+        }
+
+        let parsed: VerifyResponseBody = resp
+            .json()
+            .await
+            .map_err(|e| format!("x402 facilitator response parse: {e}"))?;
+
+        if parsed.is_valid {
+            Ok(parsed.payer.unwrap_or_else(|| "unknown".into()))
+        } else {
+            let reason = parsed
+                .invalid_reason
+                .or(parsed.invalid_message)
+                .unwrap_or_else(|| "invalid_x402_payment".into());
+            Err(reason)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn client_for(server_uri: String) -> HttpX402 {
+        HttpX402::new(format!("{server_uri}/verify"), "test-bearer-token".into()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn valid_response_returns_payer() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/verify"))
+            .and(header("authorization", "Bearer test-bearer-token"))
+            .and(header("content-type", "application/json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "isValid": true,
+                "payer": "0x857b06519E91e3A54538791bDbb0E22373e36b66"
+            })))
+            .mount(&server)
+            .await;
+        let client = client_for(server.uri());
+        let result = client.verify("{}", &[0u8; 32]).await;
+        assert_eq!(
+            result,
+            Ok("0x857b06519E91e3A54538791bDbb0E22373e36b66".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_response_returns_invalid_reason() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "isValid": false,
+                "invalidReason": "insufficient_funds",
+                "payer": "0x857b06519E91e3A54538791bDbb0E22373e36b66"
+            })))
+            .mount(&server)
+            .await;
+        let client = client_for(server.uri());
+        let result = client.verify("{}", &[0u8; 32]).await;
+        assert_eq!(result, Err("insufficient_funds".to_string()));
+    }
+
+    #[tokio::test]
+    async fn invalid_response_falls_back_to_invalid_message() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "isValid": false,
+                "invalidMessage": "payment authorization expired"
+            })))
+            .mount(&server)
+            .await;
+        let client = client_for(server.uri());
+        let result = client.verify("{}", &[0u8; 32]).await;
+        assert_eq!(result, Err("payment authorization expired".to_string()));
+    }
+
+    #[tokio::test]
+    async fn invalid_response_with_neither_field_uses_generic_default() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "isValid": false })))
+            .mount(&server)
+            .await;
+        let client = client_for(server.uri());
+        let result = client.verify("{}", &[0u8; 32]).await;
+        assert_eq!(result, Err("invalid_x402_payment".to_string()));
+    }
+
+    #[tokio::test]
+    async fn malformed_response_body_returns_parse_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .mount(&server)
+            .await;
+        let client = client_for(server.uri());
+        let result = client.verify("{}", &[0u8; 32]).await;
+        match result {
+            Err(e) if e.contains("response parse") => {}
+            other => panic!("expected parse error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn non_2xx_returns_facilitator_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("upstream down"))
+            .mount(&server)
+            .await;
+        let client = client_for(server.uri());
+        let result = client.verify("{}", &[0u8; 32]).await;
+        match result {
+            Err(e) if e.contains("non-2xx") && e.contains("500") => {}
+            other => panic!("expected non-2xx error, got {other:?}"),
+        }
+    }
+
+    /// Connection that accepts but never responds; client must time out
+    /// rather than hang. Uses a raw TCP listener instead of wiremock
+    /// because wiremock's response delay is bounded by its own runtime
+    /// scheduling and is less reliable than "accept and drop".
+    #[tokio::test]
+    async fn timeout_returns_unreachable_error() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _accept_task = tokio::spawn(async move {
+            // Hold connections open without responding.
+            let _conns: Vec<tokio::net::TcpStream> = Vec::new();
+            loop {
+                match listener.accept().await {
+                    Ok((stream, _)) => {
+                        // leak the stream so the kernel doesn't RST it
+                        std::mem::forget(stream);
+                    }
+                    Err(_) => return,
+                }
+            }
+        });
+        let client = HttpX402::with_config(
+            format!("http://{addr}/verify"),
+            "tok".into(),
+            Duration::from_millis(200),
+        )
+        .unwrap();
+        let result = client.verify("{}", &[0u8; 32]).await;
+        match result {
+            Err(e) if e.contains("unreachable") => {}
+            other => panic!("expected unreachable error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn constructor_rejects_empty_bearer() {
+        let err =
+            HttpX402::new("https://example.test/verify".into(), "".into()).unwrap_err();
+        assert!(err.contains("bearer"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn constructor_rejects_empty_url() {
+        let err = HttpX402::new("".into(), "tok".into()).unwrap_err();
+        assert!(err.contains("facilitator_url"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn request_body_is_forwarded_verbatim() {
+        let server = MockServer::start().await;
+        let body = r#"{"x402Version":1,"paymentPayload":{"scheme":"exact"},"paymentRequirements":{"asset":"0x036CbD53842c5426634e7929541eC2318f3dCF7e"}}"#;
+        Mock::given(method("POST"))
+            .and(path("/verify"))
+            .and(wiremock::matchers::body_string(body))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "isValid": true, "payer": "0xabc" })),
+            )
+            .mount(&server)
+            .await;
+        let client = client_for(server.uri());
+        assert_eq!(client.verify(body, &[0u8; 32]).await, Ok("0xabc".into()));
     }
 }

--- a/bls-device/src/x402.rs
+++ b/bls-device/src/x402.rs
@@ -88,6 +88,7 @@ const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 /// A response with `isValid: true` but a missing or blank `payer` is
 /// rejected as `x402_valid_missing_payer` — we never invent a success
 /// identifier.
+#[derive(Debug)]
 pub struct HttpX402 {
     facilitator_url: String,
     bearer: String,

--- a/bls-device/src/x402.rs
+++ b/bls-device/src/x402.rs
@@ -85,6 +85,9 @@ const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 /// `payment_id` success field. The current canonical x402 verify response
 /// has no such field; the documented success identifier is `payer`. The
 /// trait's `Result<String, String>` therefore returns `payer` on success.
+/// A response with `isValid: true` but a missing or blank `payer` is
+/// rejected as `x402_valid_missing_payer` — we never invent a success
+/// identifier.
 pub struct HttpX402 {
     facilitator_url: String,
     bearer: String,
@@ -174,7 +177,15 @@ impl X402Verifier for HttpX402 {
             .map_err(|e| format!("x402 facilitator response parse: {e}"))?;
 
         if parsed.is_valid {
-            Ok(parsed.payer.unwrap_or_else(|| "unknown".into()))
+            // Reject success-without-payer: returning a placeholder string
+            // here would be inventing a payment identifier, exactly the
+            // discipline issue #45 forbids. Whitespace-only payer is
+            // treated the same as missing.
+            let payer = parsed
+                .payer
+                .filter(|p| !p.trim().is_empty())
+                .ok_or_else(|| "x402_valid_missing_payer".to_string())?;
+            Ok(payer)
         } else {
             let reason = parsed
                 .invalid_reason
@@ -214,6 +225,40 @@ mod tests {
         assert_eq!(
             result,
             Ok("0x857b06519E91e3A54538791bDbb0E22373e36b66".to_string())
+        );
+    }
+
+    /// Lock the no-invented-receipt discipline: `isValid: true` without a
+    /// usable `payer` MUST NOT decay into a placeholder Ok value. Both
+    /// missing-field and blank-string variants are rejected with the same
+    /// stable reason token so log scrapers / alerting don't fragment.
+    #[tokio::test]
+    async fn valid_response_without_payer_is_error() {
+        // Case 1: payer field absent.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "isValid": true })))
+            .mount(&server)
+            .await;
+        let client = client_for(server.uri());
+        assert_eq!(
+            client.verify("{}", &[0u8; 32]).await,
+            Err("x402_valid_missing_payer".to_string())
+        );
+
+        // Case 2: payer present but whitespace-only.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "isValid": true,
+                "payer": "   "
+            })))
+            .mount(&server)
+            .await;
+        let client = client_for(server.uri());
+        assert_eq!(
+            client.verify("{}", &[0u8; 32]).await,
+            Err("x402_valid_missing_payer".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary

Lands the HttpX402 production-client follow-up that sat on `claude/audit-resolution-handoff-QTKRe` after PR #52 merged. Closes the audit follow-up tracked by #45 and pulls the in-flight CI repair onto a visible review surface.

## Closes

- Closes #45 — HttpX402 production client per Coinbase facilitator spec.

## Commits in this PR

- `d452394` — HttpX402 production client for x402 facilitator
- `69e221f` — reject `isValid: true` with missing or blank `payer` (no-invented-receipt discipline; new `valid_response_without_payer_is_error` test; stable `x402_valid_missing_payer` reason token)
- `2c8a17f` — `#[derive(Debug)]` on `HttpX402` so constructor tests using `unwrap_err()` compile (CI repair)

## Out of scope (still open)

- #53 — O-701 stage-3 request-hash / `paymentRequirements` binding invariant. Intentionally not in this PR; tracked as the next discrete brick.

## Test expectation

```
cargo test --workspace --features bls-device/mock-x402
```

## Merge gate

Open as draft so checks surface. Do not merge until the `bls-device` workflow run on `2c8a17f` is green.

---

Context: this PR exists to give the post-#52 work a visible CI surface (the branch had been receiving direct pushes with no PR open). It does not introduce code beyond the three commits listed above.

---
_Generated by [Claude Code](https://claude.ai/code/session_013zFVvbXKny8oY83fJLmu9C)_